### PR TITLE
Sprint 4: On document upload, document id is pushed to RabbitMQ queue

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic",
+    "java.debug.settings.onBuildFailureProceed": true,
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/dms-backend/pom.xml
+++ b/dms-backend/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<optional>true</optional>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -56,6 +56,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-amqp</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>javax.validation</groupId>

--- a/dms-backend/src/main/java/at/technikumwien/dmsbackend/config/RabbitMQConfig.java
+++ b/dms-backend/src/main/java/at/technikumwien/dmsbackend/config/RabbitMQConfig.java
@@ -1,0 +1,42 @@
+package at.technikumwien.dmsbackend.config;
+
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import at.technikumwien.dmsbackend.service.impl.RabbitMQListenerImpl;
+
+@Configuration
+public class RabbitMQConfig {
+
+    public static final String QUEUE_NAME = "documentQueue";
+
+    @Bean
+    public Queue queue() {
+        return new Queue(QUEUE_NAME, false);
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        return new RabbitTemplate(connectionFactory);
+    }
+
+    @Bean
+    public SimpleMessageListenerContainer container(ConnectionFactory connectionFactory,
+                                                    MessageListenerAdapter listenerAdapter) {
+        SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.setQueueNames(QUEUE_NAME);
+        container.setMessageListener(listenerAdapter);
+        return container;
+    }
+
+    @Bean
+    public MessageListenerAdapter listenerAdapter(RabbitMQListenerImpl receiver) {
+        return new MessageListenerAdapter(receiver, "receiveMessage");
+    }
+}

--- a/dms-backend/src/main/java/at/technikumwien/dmsbackend/controller/DocumentController.java
+++ b/dms-backend/src/main/java/at/technikumwien/dmsbackend/controller/DocumentController.java
@@ -1,22 +1,32 @@
 package at.technikumwien.dmsbackend.controller;
 
-import at.technikumwien.dmsbackend.persistence.entity.DocumentEntity;
-import at.technikumwien.dmsbackend.service.DocumentService;
-import at.technikumwien.dmsbackend.service.dto.*;
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.List;
+
+import javax.validation.Valid;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-import javax.validation.Valid;
+import at.technikumwien.dmsbackend.service.DocumentService;
+import at.technikumwien.dmsbackend.service.dto.DocumentDTO;
+import lombok.RequiredArgsConstructor;
 
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/v1/documents")
 public class DocumentController {
-    @Autowired
-    private DocumentService documentService;
+    
+    private final DocumentService documentService;
 
     @PostMapping
     public ResponseEntity<DocumentDTO> create(@Valid @RequestBody DocumentDTO document) {

--- a/dms-backend/src/main/java/at/technikumwien/dmsbackend/exception/DocumentUploadException.java
+++ b/dms-backend/src/main/java/at/technikumwien/dmsbackend/exception/DocumentUploadException.java
@@ -1,0 +1,7 @@
+package at.technikumwien.dmsbackend.exception;
+
+public class DocumentUploadException extends RuntimeException {
+    public DocumentUploadException(String message) {
+        super(message);
+    }
+}

--- a/dms-backend/src/main/java/at/technikumwien/dmsbackend/exception/GlobalExceptionHandler.java
+++ b/dms-backend/src/main/java/at/technikumwien/dmsbackend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package at.technikumwien.dmsbackend.exception;
+
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(DocumentUploadException.class)
+    public ResponseEntity<String> handleDocumentUploadException(DocumentUploadException e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+    }
+}

--- a/dms-backend/src/main/java/at/technikumwien/dmsbackend/service/DocumentService.java
+++ b/dms-backend/src/main/java/at/technikumwien/dmsbackend/service/DocumentService.java
@@ -1,10 +1,9 @@
 package at.technikumwien.dmsbackend.service;
 
 
-import at.technikumwien.dmsbackend.service.dto.DocumentDTO;
-
-import javax.print.Doc;
 import java.util.List;
+
+import at.technikumwien.dmsbackend.service.dto.DocumentDTO;
 
 
 public interface DocumentService {

--- a/dms-backend/src/main/java/at/technikumwien/dmsbackend/service/impl/DocumentServiceImpl.java
+++ b/dms-backend/src/main/java/at/technikumwien/dmsbackend/service/impl/DocumentServiceImpl.java
@@ -47,7 +47,7 @@ public class DocumentServiceImpl implements DocumentService {
         documentRepository.save(entity);
         try {
             rabbitTemplate.convertAndSend(RabbitMQConfig.QUEUE_NAME, "Document uploaded with ID: " + entity.getId());
-            logger.info("Message sent to RabbitMQ: Document uploaded with ID: " + entity.getId());
+            logger.info("Message sent to RabbitMQ: Document uploaded with ID: {}", entity.getId());
         } catch (Exception e) {
             throw new DocumentUploadException("Failed to upload document: " + e.getMessage());
         }
@@ -73,7 +73,8 @@ public class DocumentServiceImpl implements DocumentService {
 
     @Override
     public DocumentDTO updateDocument(Long id, DocumentDTO updateRequest) {
-        DocumentEntity existingDocument = documentMapper.mapToEntity(getDocumentById(id));
+        DocumentEntity existingDocument = documentRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException("Document not found with ID: " + id));
 
         existingDocument.setTitle(updateRequest.getTitle());
         existingDocument.setDescription(updateRequest.getDescription());

--- a/dms-backend/src/main/java/at/technikumwien/dmsbackend/service/impl/RabbitMQListenerImpl.java
+++ b/dms-backend/src/main/java/at/technikumwien/dmsbackend/service/impl/RabbitMQListenerImpl.java
@@ -1,0 +1,15 @@
+package at.technikumwien.dmsbackend.service.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RabbitMQListenerImpl {
+
+    private static final Logger logger = LoggerFactory.getLogger(RabbitMQListenerImpl.class);
+
+    public void receiveMessage(String message) {
+        logger.info("Received message from RabbitMQ: {}", message);
+    }
+}

--- a/dms-backend/src/main/resources/application.properties
+++ b/dms-backend/src/main/resources/application.properties
@@ -5,3 +5,7 @@ spring.datasource.password=dms
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
+spring.rabbitmq.host=rabbitmq
+spring.rabbitmq.port=5672
+spring.rabbitmq.username=dms
+spring.rabbitmq.password=dms

--- a/dms-backend/src/test/java/at/technikumwien/dmsbackend/controller/DocumentControllerTest.java
+++ b/dms-backend/src/test/java/at/technikumwien/dmsbackend/controller/DocumentControllerTest.java
@@ -1,0 +1,162 @@
+package at.technikumwien.dmsbackend.controller;
+
+import at.technikumwien.dmsbackend.service.DocumentService;
+import at.technikumwien.dmsbackend.service.dto.DocumentDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class DocumentControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private DocumentService documentService;
+
+    @InjectMocks
+    private DocumentController documentController;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        this.mockMvc = MockMvcBuilders.standaloneSetup(documentController).build();
+    }
+
+    @Test
+    void testCreateDocument() throws Exception {
+        DocumentDTO documentDTO = DocumentDTO.builder()
+                .id(1L)
+                .title("Title")
+                .description("Description")
+                .type("Type")
+                .size(123L)
+                .uploadDate("2024-11-04")
+                .build();
+
+        when(documentService.uploadDocument(any(DocumentDTO.class))).thenReturn(documentDTO);
+
+        mockMvc.perform(post("/api/v1/documents")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"Title\", \"description\":\"Description\", \"type\":\"Type\", \"size\":123, \"uploadDate\":\"2024-11-04\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.title").value("Title"));
+    }
+
+    @Test
+    void testGetDocumentById() throws Exception {
+        DocumentDTO documentDTO = DocumentDTO.builder()
+                .id(1L)
+                .title("Title")
+                .description("Description")
+                .type("Type")
+                .size(123L)
+                .uploadDate("2024-11-04")
+                .build();
+
+        when(documentService.getDocumentById(1L)).thenReturn(documentDTO);
+
+        mockMvc.perform(get("/api/v1/documents/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.title").value("Title"));
+    }
+
+    @Test
+    void testGetDocuments() throws Exception {
+        DocumentDTO documentDTO = DocumentDTO.builder()
+                .id(1L)
+                .title("Title")
+                .description("Description")
+                .type("Type")
+                .size(123L)
+                .uploadDate("2024-11-04")
+                .build();
+
+        when(documentService.getAllDocuments()).thenReturn(Collections.singletonList(documentDTO));
+
+        mockMvc.perform(get("/api/v1/documents"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id").value(1L));
+    }
+
+    @Test
+    void testUpdateDocument() throws Exception {
+        DocumentDTO documentDTO = DocumentDTO.builder()
+                .id(1L)
+                .title("Updated Title")
+                .description("Description")
+                .type("Type")
+                .size(123L)
+                .uploadDate("2024-11-04")
+                .build();
+
+        when(documentService.updateDocument(anyLong(), any(DocumentDTO.class))).thenReturn(documentDTO);
+
+        mockMvc.perform(put("/api/v1/documents/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"Updated Title\", \"description\":\"Description\", \"type\":\"Type\", \"size\":123, \"uploadDate\":\"2024-11-04\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Updated Title"));
+    }
+
+    @Test
+    void testDeleteDocument() throws Exception {
+        mockMvc.perform(delete("/api/v1/documents/1"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void testSearchDocuments() throws Exception {
+        DocumentDTO documentDTO = DocumentDTO.builder()
+                .id(1L)
+                .title("Title")
+                .description("Description")
+                .type("Type")
+                .size(123L)
+                .uploadDate("2024-11-04")
+                .build();
+
+        when(documentService.searchDocuments("Title")).thenReturn(Collections.singletonList(documentDTO));
+
+        mockMvc.perform(get("/api/v1/documents/search")
+                .param("query", "Title"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].title").value("Title"));
+    }
+
+    @Test
+    void testGetDocumentMetadata() throws Exception {
+        DocumentDTO documentDTO = DocumentDTO.builder()
+                .id(1L)
+                .title("Title")
+                .description("Description")
+                .type("Type")
+                .size(123L)
+                .uploadDate("2024-11-04")
+                .build();
+
+        when(documentService.getDocumentMetadata(1L)).thenReturn(documentDTO);
+
+        mockMvc.perform(get("/api/v1/documents/1/metadata"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.title").value("Title"));
+    }
+}

--- a/dms-backend/src/test/java/at/technikumwien/dmsbackend/service/impl/DocumentServiceImplTest.java
+++ b/dms-backend/src/test/java/at/technikumwien/dmsbackend/service/impl/DocumentServiceImplTest.java
@@ -1,0 +1,193 @@
+package at.technikumwien.dmsbackend.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+import at.technikumwien.dmsbackend.config.RabbitMQConfig;
+import at.technikumwien.dmsbackend.persistence.entity.DocumentEntity;
+import at.technikumwien.dmsbackend.persistence.repository.DocumentRepository;
+import at.technikumwien.dmsbackend.service.dto.DocumentDTO;
+import at.technikumwien.dmsbackend.service.mapper.DocumentMapper;
+
+class DocumentServiceImplTest {
+
+    @Mock
+    private DocumentRepository documentRepository;
+
+    @Mock
+    private DocumentMapper documentMapper;
+
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+
+    @InjectMocks
+    private DocumentServiceImpl documentService;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testUploadDocument() {
+        DocumentDTO documentDTO = DocumentDTO.builder()
+                .title("Title")
+                .description("Description")
+                .type("Type")
+                .size(123L)
+                .uploadDate("2024-11-04")
+                .build();
+    
+        DocumentEntity documentEntity = DocumentEntity.builder()
+                .id(1L)  
+                .title("Title")
+                .description("Description")
+                .type("Type")
+                .size(123L)
+                .uploadDate(LocalDate.parse("2024-11-04"))
+                .build();
+    
+        when(documentRepository.save(any(DocumentEntity.class))).thenAnswer(invocation -> {
+            DocumentEntity savedEntity = invocation.getArgument(0);
+            savedEntity.setId(1L);
+            return savedEntity;
+        });
+    
+        when(documentMapper.mapToDto(any(DocumentEntity.class))).thenReturn(documentDTO);
+        
+        DocumentDTO result = documentService.uploadDocument(documentDTO);
+        
+        assertNotNull(result);
+        verify(rabbitTemplate, times(1)).convertAndSend(RabbitMQConfig.QUEUE_NAME, "Document uploaded with ID: " + documentEntity.getId());
+    }
+    
+    
+
+    @Test
+    void testGetDocumentById() {
+        DocumentEntity documentEntity = DocumentEntity.builder()
+                .id(1L)
+                .title("Title")
+                .description("Description")
+                .type("Type")
+                .size(123L)
+                .uploadDate(LocalDate.now())
+                .build();
+
+        when(documentRepository.findById(1L)).thenReturn(Optional.of(documentEntity));
+        when(documentMapper.mapToDto(documentEntity)).thenReturn(DocumentDTO.builder()
+                .id(1L)
+                .title("Title")
+                .description("Description")
+                .type("Type")
+                .size(123L)
+                .uploadDate("2024-11-04")
+                .build());
+
+        DocumentDTO result = documentService.getDocumentById(1L);
+
+        assertEquals("Title", result.getTitle());
+    }
+
+    @Test
+    void testGetAllDocuments() {
+        DocumentEntity documentEntity = DocumentEntity.builder()
+                .id(1L)
+                .title("Title")
+                .description("Description")
+                .type("Type")
+                .size(123L)
+                .uploadDate(LocalDate.now())
+                .build();
+
+        when(documentRepository.findAll()).thenReturn(Collections.singletonList(documentEntity));
+        when(documentMapper.mapToDto(documentEntity)).thenReturn(DocumentDTO.builder()
+                .id(1L)
+                .title("Title")
+                .description("Description")
+                .type("Type")
+                .size(123L)
+                .uploadDate("2024-11-04")
+                .build());
+
+        List<DocumentDTO> results = documentService.getAllDocuments();
+
+        assertEquals(1, results.size());
+    }
+
+    @Test
+    void testUpdateDocument() {
+        DocumentDTO updatedDTO = DocumentDTO.builder()
+                .id(1L)
+                .title("Updated Title")
+                .description("Description")
+                .type("Type")
+                .size(123L)
+                .uploadDate("2024-11-04")
+                .build();
+
+        DocumentEntity existingEntity = DocumentEntity.builder()
+                .id(1L)
+                .title("Title")
+                .description("Description")
+                .type("Type")
+                .size(123L)
+                .uploadDate(LocalDate.now())
+                .build();
+
+        when(documentRepository.findById(1L)).thenReturn(Optional.of(existingEntity));
+        when(documentMapper.mapToDto(any(DocumentEntity.class))).thenReturn(updatedDTO);
+
+        DocumentDTO result = documentService.updateDocument(1L, updatedDTO);
+
+        assertEquals("Updated Title", result.getTitle());
+    }
+
+    @Test
+    void testDeleteDocument() {
+        documentService.deleteDocument(1L);
+        verify(documentRepository, times(1)).deleteById(1L);
+    }
+
+    @Test
+    void testGetDocumentMetadata() {
+        DocumentEntity documentEntity = DocumentEntity.builder()
+                .id(1L)
+                .title("Title")
+                .description("Description")
+                .type("Type")
+                .size(123L)
+                .uploadDate(LocalDate.now())
+                .build();
+
+        when(documentRepository.findById(1L)).thenReturn(Optional.of(documentEntity));
+        when(documentMapper.mapToDto(documentEntity)).thenReturn(DocumentDTO.builder()
+                .id(1L)
+                .title("Title")
+                .description("Description")
+                .type("Type")
+                .size(123L)
+                .uploadDate("2024-11-04")
+                .build());
+
+        DocumentDTO result = documentService.getDocumentMetadata(1L);
+
+        assertEquals("Title", result.getTitle());
+    }
+}

--- a/dms-frontend/src/app/components/documents/document-upload-modal/document-upload-modal.component.html
+++ b/dms-frontend/src/app/components/documents/document-upload-modal/document-upload-modal.component.html
@@ -1,7 +1,23 @@
 <app-modal title="UPLOAD_DOCUMENT" [loading]="loading" submitText="UPLOAD" closeText="CANCEL"
            (submitClicked)="submit()">
-  <mdb-file-upload [defaultMsg]="('CHOOSE_FILE'|translate)" [acceptedExtensions]="'.pdf'"
-                   [formatError]="'INCORRECT_FILE_FORMAT'|translate" [mainError]="'ERROR_OCCURRED'|translate"
-                   [removeBtn]="'REMOVE'|translate" [previewMsg]="'FILE_REPLACE'|translate"
-                   (fileAdded)="file = $event" (uploadError)="file = null" (fileRemoved)="file = null" ></mdb-file-upload>
+  <form [formGroup]="formGroup">
+    <div class="row gap-4">
+      <div class="col-12">
+        <app-form-input [formGroup]="formGroup" [isRequired]="true" label="Title" [controlName]="'title'"
+                        [id]="'title'"></app-form-input>
+      </div>
+      <div class="col-12">
+        <app-text-area-input [formGroup]="formGroup" [id]="'description'" [controlName]="'description'"
+                             label="Description" [isRequired]="true" [rows]="2"></app-text-area-input>
+      </div>
+
+      <div class="col-12">
+        <mdb-file-upload [defaultMsg]="('CHOOSE_FILE'|translate)" [acceptedExtensions]="'.pdf'"
+                         [formatError]="'INCORRECT_FILE_FORMAT'|translate" [mainError]="'ERROR_OCCURRED'|translate"
+                         [removeBtn]="'REMOVE'|translate" [previewMsg]="'FILE_REPLACE'|translate"
+                         (fileAdded)="onFileUploaded($event)" (uploadError)="file = null"
+                         (fileRemoved)="file = null"></mdb-file-upload>
+      </div>
+    </div>
+  </form>
 </app-modal>

--- a/dms-frontend/src/app/components/documents/document-upload-modal/document-upload-modal.component.ts
+++ b/dms-frontend/src/app/components/documents/document-upload-modal/document-upload-modal.component.ts
@@ -1,8 +1,15 @@
 import { Component } from '@angular/core';
-import {ModalComponent} from "../../utils/modal/modal.component";
-import {MdbFileUploadModule} from "mdb-angular-file-upload";
-import {MdbModalRef} from "mdb-angular-ui-kit/modal";
-import {TranslateModule} from "@ngx-translate/core";
+import { ModalComponent } from "../../utils/modal/modal.component";
+import { MdbFileUploadModule } from "mdb-angular-file-upload";
+import { MdbModalRef } from "mdb-angular-ui-kit/modal";
+import { TranslateModule } from "@ngx-translate/core";
+import { DocumentService } from "../../../services/document.service";
+import { finalize } from "rxjs";
+import { DocumentModel } from "../../../models/document.model";
+import { CustomNotificationService } from "../../../services/custom-notification.service";
+import {FormInputComponent} from "../../utils/form-input/form-input.component";
+import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from "@angular/forms";
+import {TextAreaInputComponent} from "../../utils/text-area-input/text-area-input.component";
 
 @Component({
   selector: 'app-document-upload-modal',
@@ -10,25 +17,75 @@ import {TranslateModule} from "@ngx-translate/core";
   imports: [
     ModalComponent,
     MdbFileUploadModule,
-    TranslateModule
+    TranslateModule,
+    FormInputComponent,
+    ReactiveFormsModule,
+    TextAreaInputComponent
   ],
   templateUrl: './document-upload-modal.component.html',
   styleUrl: './document-upload-modal.component.scss'
 })
 export class DocumentUploadModalComponent {
-  loading: boolean = false
-  file: File[] | null = null
+  loading: boolean = false;
+  file: File | null = null;
+  fileDataBase64: string | null = null; // Store the base64 encoded file data
+  formGroup: FormGroup
 
-  constructor(private modalRef: MdbModalRef<ModalComponent>) {}
+  constructor(
+    private modalRef: MdbModalRef<ModalComponent>,
+    private notificationService: CustomNotificationService,
+    private documentService: DocumentService,
+    private formBuilder: FormBuilder
+  ) {
+    this.formGroup = this.formBuilder.group({
+      title: [null, Validators.required],
+      description: [null, Validators.required],
+    })
+  }
+
+  onFileUploaded(event: any) {
+    const file = event[0] as File;
+
+    if (file) {
+      this.file = file;
+
+      // Convert file to base64 string
+      const reader = new FileReader();
+      reader.onload = () => {
+        this.fileDataBase64 = reader.result ? reader.result.toString().split(",")[1] : null;
+      };
+      reader.readAsDataURL(this.file);
+    } else {
+      this.file = null;
+      this.fileDataBase64 = null;
+    }
+  }
 
   submit() {
-    if(!this.file)
-      return
+    this.formGroup.markAllAsTouched()
+    if (!this.file || !this.fileDataBase64 || this.formGroup.invalid) return
 
-    this.loading = true
+    this.loading = true;
 
-    setTimeout(() => {
-      this.modalRef.close(true)
-    }, 2000)
+    const resource = {
+      title: this.formGroup.get('title')?.value,           // replace with actual title
+      description: this.formGroup.get('description')?.value, // replace with actual description
+      type: "pdf",                    // replace with actual type if dynamic
+      size: this.file.size,
+      uploadDate: new Date().toISOString().split("T")[0],  // Format to "YYYY-MM-DD",
+      fileData: this.fileDataBase64 // Send the base64-encoded file data
+    };
+
+    this.documentService.create(resource)
+      .pipe(finalize(() => (this.loading = false)))
+      .subscribe({
+        next: (document: DocumentModel) => {
+          this.modalRef.close(document);
+        },
+        error: (e) => {
+          this.notificationService.error("Fehler beim Upload");
+          console.error(e);
+        },
+      });
   }
 }

--- a/dms-frontend/src/app/components/documents/documents-table/documents-table.component.ts
+++ b/dms-frontend/src/app/components/documents/documents-table/documents-table.component.ts
@@ -42,9 +42,9 @@ export class DocumentsTableComponent extends AResourceTableComponent<DocumentMod
       filterUrlParam: 'title',
     },
     {
-      name: 'URL',
+      name: 'DESCRIPTION',
       selector: [
-        {selector: 'url'}
+        {selector: 'description'}
       ]
     },
     {

--- a/dms-frontend/src/app/components/utils/form-input/form-input.component.html
+++ b/dms-frontend/src/app/components/utils/form-input/form-input.component.html
@@ -9,8 +9,8 @@
          class="form-label"
          for="{{id()}}">{{label()}} <span *ngIf="isRequired()">*</span></label>
   <ng-content></ng-content>
-  <mdb-error *ngIf="isRequired() && control?.hasError('required') && (control?.dirty || control?.touched)">{{label()}} {{"VALIDATION.IS_REQUIRED"|translate}}.</mdb-error>
-  <mdb-error *ngIf="type() =='email' && control?.hasError('email') && (control?.dirty || control?.touched)">{{label()}} {{"VALIDATION.IS_INVALID"|translate}}.</mdb-error>
-  <mdb-error *ngIf="minLength() && control?.hasError('minlength') && (control?.dirty || control?.touched)">{{label()}} {{"VALIDATION.MIN_LENGTH"|translate:{minLength: minLength()} }}.</mdb-error>
-  <mdb-error *ngIf="min() && control?.hasError('min') && (control?.dirty || control?.touched)">{{label()}} {{"VALIDATION.MIN"|translate:{min: min()} }}.</mdb-error>
+  <mdb-error *ngIf="isRequired() && control?.hasError('required') && (control?.dirty || control?.touched)">{{label()}} is required.</mdb-error>
+  <mdb-error *ngIf="type() =='email' && control?.hasError('email') && (control?.dirty || control?.touched)">{{label()}} ist ungültig.</mdb-error>
+  <mdb-error *ngIf="minLength() && control?.hasError('minlength') && (control?.dirty || control?.touched)">{{label()}} muss mindestens {{minLength()}} Zeichen lang sein.</mdb-error>
+  <mdb-error *ngIf="min() && control?.hasError('min') && (control?.dirty || control?.touched)">{{label()}} muss mindestens {{min()}} sein.</mdb-error>
 </mdb-form-control>

--- a/dms-frontend/src/app/components/utils/text-area-input/text-area-input.component.html
+++ b/dms-frontend/src/app/components/utils/text-area-input/text-area-input.component.html
@@ -1,0 +1,13 @@
+<mdb-form-control [formGroup]="formGroup">
+        <textarea mdbInput
+                  id="{{id}}"
+                  class="form-control"
+                  [rows]="rows"
+                  [placeholder]="placeholder ?? '' | translate"
+                  formControlName="{{controlName}}"></textarea>
+  <label mdbLabel
+         class="form-label"
+         for="{{id}}">{{ label }} <span *ngIf="isRequired">*</span></label>
+  <mdb-error *ngIf="isRequired && control?.hasError('required') && (control?.dirty || control?.touched)" style="top: initial !important;">{{ label }} is required.
+  </mdb-error>
+</mdb-form-control>

--- a/dms-frontend/src/app/components/utils/text-area-input/text-area-input.component.spec.ts
+++ b/dms-frontend/src/app/components/utils/text-area-input/text-area-input.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TextAreaInputComponent } from './text-area-input.component';
+
+describe('TextAreaInputComponent', () => {
+  let component: TextAreaInputComponent;
+  let fixture: ComponentFixture<TextAreaInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TextAreaInputComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(TextAreaInputComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/dms-frontend/src/app/components/utils/text-area-input/text-area-input.component.ts
+++ b/dms-frontend/src/app/components/utils/text-area-input/text-area-input.component.ts
@@ -1,0 +1,34 @@
+import {Component, Input} from '@angular/core';
+import {AbstractControl, FormGroup, FormsModule, ReactiveFormsModule} from "@angular/forms";
+import {MdbFormsModule} from "mdb-angular-ui-kit/forms";
+import {NgIf} from "@angular/common";
+import {MdbValidationModule} from "mdb-angular-ui-kit/validation";
+import {TranslateModule} from "@ngx-translate/core";
+
+@Component({
+  selector: 'app-text-area-input',
+  standalone: true,
+  imports: [
+    FormsModule,
+    MdbFormsModule,
+    ReactiveFormsModule,
+    NgIf,
+    MdbValidationModule,
+    TranslateModule,
+  ],
+  templateUrl: './text-area-input.component.html',
+  styleUrl: './text-area-input.component.scss',
+})
+export class TextAreaInputComponent {
+  @Input({ required: true }) id!: string;
+  @Input({ required: true }) label!: string;
+  @Input({ required: true }) controlName!: string;
+  @Input({ required: true }) formGroup!: FormGroup;
+  @Input() isRequired: boolean = false;
+  @Input() rows: number = 4;
+  @Input() placeholder: string | null = null;
+
+  get control(): AbstractControl | null {
+    return this.formGroup!.get(this.controlName!);
+  }
+}

--- a/dms-frontend/src/app/models/document.model.ts
+++ b/dms-frontend/src/app/models/document.model.ts
@@ -1,6 +1,6 @@
 export interface DocumentModel {
   id: number
-  url: string
+  url?: string
   title: string
   description: string
   type: string

--- a/dms-frontend/src/app/services/resource.service.ts
+++ b/dms-frontend/src/app/services/resource.service.ts
@@ -33,6 +33,14 @@ export abstract class ResourceService<M extends AModel> {
   private getAllSubscription: Subscription | null = null;
   private cancelRequest$ = new Subject<void>();
 
+  addModel(model: M) {
+    this.apiResponse.update((apiResp) => {
+      const updatedData = apiResp.data
+      updatedData.push(model)
+      return { ...apiResp, data: updatedData };
+    });
+  }
+
   removeModel(id: number) {
     // Update the concrete models
     this.usedConcreteModels.update((models) => {
@@ -137,6 +145,18 @@ export abstract class ResourceService<M extends AModel> {
             this.breadcrumbService.updateCurrentConcreteModel(
               m.title!,
             );
+          },
+        }),
+      );
+  }
+
+  create(data: any): Observable<M> {
+    return this.http
+      .post<M>(environment.apiUrl + this.resourceUrl, data)
+      .pipe(
+        tap({
+          next: (m: M) => {
+            this.addModel(m)
           },
         }),
       );

--- a/dms-frontend/src/styles.scss
+++ b/dms-frontend/src/styles.scss
@@ -14,3 +14,7 @@
   height: 20px;
   margin-top: 2px;
 }
+
+mdb-error {
+  top: 33px !important;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,47 +1,59 @@
 services:
-  frontend:
-    container_name: dms-frontend
-    build:
-      context: ./dms-frontend
-      dockerfile: Dockerfile
+    frontend:
+        container_name: dms-frontend
+        build:
+            context: ./dms-frontend
+            dockerfile: Dockerfile
 
-  nginx:
-    container_name: nginx
-    image: nginx:stable-alpine
-    expose:
-      - "80"
-    ports:
-      - "80:80"
-    volumes:
-      - ./nginx.middle.conf:/etc/nginx/conf.d/default.conf:rw
+    nginx:
+        container_name: nginx
+        image: nginx:stable-alpine
+        expose:
+            - "80"
+        ports:
+            - "80:80"
+        depends_on:
+            - backend
+        volumes:
+            - ./nginx.middle.conf:/etc/nginx/conf.d/default.conf:rw
 
-  backend:
-    build:
-      context: ./dms-backend
-      dockerfile: ./Dockerfile
-    container_name: dms-backend
-    depends_on:
-      - db
-    environment:
-      - POSTGRES_USER=dms
-      - POSTGRES_PASSWORD=dms
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/dms
-      - SPRING_DATASOURCE_USERNAME=dms
-      - SPRING_DATASOURCE_PASSWORD=dms
-      - SPRING_JPA_HIBERNATE_DDL_AUTO=update
-    ports:
-      - "8080:8080"
+    backend:
+        build:
+            context: ./dms-backend
+            dockerfile: ./Dockerfile
+        container_name: dms-backend
+        depends_on:
+            - db
+        environment:
+            - POSTGRES_USER=dms
+            - POSTGRES_PASSWORD=dms
+            - SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/dms
+            - SPRING_DATASOURCE_USERNAME=dms
+            - SPRING_DATASOURCE_PASSWORD=dms
+            - SPRING_JPA_HIBERNATE_DDL_AUTO=update
+        ports:
+            - "8080:8080"
 
-  db:
-    container_name: dms-db
-    image: postgres:latest
-    environment:
-      POSTGRES_DB: dms
-      POSTGRES_USER: dms
-      POSTGRES_PASSWORD: dms
-    ports:
-      - "5432:5432"
-    volumes:
-      - db-data:/var/lib/postgresql/data
+    db:
+        container_name: dms-db
+        image: postgres:latest
+        environment:
+            POSTGRES_DB: dms
+            POSTGRES_USER: dms
+            POSTGRES_PASSWORD: dms
+        ports:
+            - "5432:5432"
+        volumes:
+            - db-data:/var/lib/postgresql/data
+
+    rabbitmq:
+        container_name: rabbitmq
+        image: rabbitmq:management
+        ports:
+            - "5672:5672"
+            - "9093:15672"
+        environment:
+            - RABBITMQ_DEFAULT_USER=dms
+            - RABBITMQ_DEFAULT_PASS=dms
 volumes:
-  db-data:
+    db-data:


### PR DESCRIPTION
dms-backend acts both as a Producer and as a Consumer - in sprint 5 the OCR service will act as a Consumer. In order to test the functionality:
1. run docker compose up --build (not in detached mode)
2. send the following request to the backend via Postman/Insomnia:
POST http://localhost:8080/api/v1/documents
{
    "title": "Example Document",
    "description": "This is a sample description for the document.",
    "type": "PDF",
    "size": 1024,
    "uploadDate": "2024-11-03",
    "fileData": "VGhpcyBpcyBhIHNhbXBsZSBmaWxlIGRhdGEu"
}
3. The terminal where docker containers were started should show similar logs:
Message sent to RabbitMQ: Document uploaded with ID: 15
Received message from RabbitMQ: Document uploaded with ID: 15

There seems to be a problem with frontend: when sending the request above via Insomnia, the document entry appears in the db and the message gets correctly sent to the queue. However, when uploading a document from frontend none of this works - most likely fallacious request body, ref. DocumentDto in backend. @if22b150 can you take a look at the frontend? For now I am no longer working on this branch, so you can either keep working here or merge it and make another fix branch.